### PR TITLE
Add execution time in the demo and console log

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -27,6 +27,7 @@ const App = () => {
     clicks: [clicks],
     image: [, setImage],
     maskImg: [, setMaskImg],
+    executionTime: [, setExecutionTime]
   } = useContext(AppContext)!;
   const [model, setModel] = useState<InferenceSession | null>(null); // ONNX model
   const [tensor, setTensor] = useState<Tensor | null>(null); // Image embedding tensor
@@ -113,7 +114,12 @@ const App = () => {
         });
         if (feeds === undefined) return;
         // Run the SAM ONNX model with the feeds returned from modelData()
+        const startTime = performance.now();
         const results = await model.run(feeds);
+        const endTime = performance.now();
+        const executionTime = endTime - startTime;
+        setExecutionTime(executionTime);
+        console.log(`model.run() took ${executionTime} ms`);
         const output = results[model.outputNames[0]];
         // The predicted mask returned from the ONNX model is an array which is 
         // rendered as an HTML image using onnxMaskToImage() from maskUtils.tsx.

--- a/demo/src/components/Stage.tsx
+++ b/demo/src/components/Stage.tsx
@@ -14,6 +14,7 @@ const Stage = () => {
   const {
     clicks: [, setClicks],
     image: [image],
+    executionTime: [executionTime]
   } = useContext(AppContext)!;
 
   const getClick = (x: number, y: number): modelInputProps => {
@@ -38,9 +39,12 @@ const Stage = () => {
 
   const flexCenterClasses = "flex items-center justify-center";
   return (
-    <div className={`${flexCenterClasses} w-full h-full`}>
-      <div className={`${flexCenterClasses} relative w-[90%] h-[90%]`}>
+    <div className={`${flexCenterClasses} w-full h-full flex-col`}>
+      <div className={`${flexCenterClasses} relative w-[80%] h-[80%]`}>
         <Tool handleMouseMove={handleMouseMove} />
+      </div>
+      <div className="mt-2">
+        Segment Anything Asynchronous Execution Time (ms): {executionTime}
       </div>
     </div>
   );

--- a/demo/src/components/hooks/context.tsx
+++ b/demo/src/components/hooks/context.tsx
@@ -14,6 +14,7 @@ const AppContextProvider = (props: {
   const [clicks, setClicks] = useState<Array<modelInputProps> | null>(null);
   const [image, setImage] = useState<HTMLImageElement | null>(null);
   const [maskImg, setMaskImg] = useState<HTMLImageElement | null>(null);
+  const [executionTime, setExecutionTime] = useState<number | null>(null);
 
   return (
     <AppContext.Provider
@@ -21,6 +22,7 @@ const AppContextProvider = (props: {
         clicks: [clicks, setClicks],
         image: [image, setImage],
         maskImg: [maskImg, setMaskImg],
+        executionTime: [executionTime, setExecutionTime]
       }}
     >
       {props.children}

--- a/demo/src/components/hooks/createContext.tsx
+++ b/demo/src/components/hooks/createContext.tsx
@@ -20,6 +20,10 @@ interface contextProps {
     maskImg: HTMLImageElement | null,
     setMaskImg: (e: HTMLImageElement | null) => void
   ];
+  executionTime: [
+    executionTime: number | null,
+    setExecutionTime: (e: number | null) => void
+  ]
 }
 
 const AppContext = createContext<contextProps | null>(null);


### PR DESCRIPTION
Add execution time information for model.run(feeds) in the web page and the console log of dev tools which didn't show in the segment anything demo.

@fdwr PTAL.

![execution_time](https://github.com/fdwr/segment-anything/assets/5017359/b8902dd1-280d-489a-8dc2-d92dde1170e6)
