### PR TITLE
Show 2 digits to appear after the decimal point for execution time

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -148,9 +148,9 @@ const App = () => {
         const startTime = performance.now();
         const results = await model.run(feeds);
         const endTime = performance.now();
-        const eT = endTime - startTime;
-        setExecutionTime(eT);
-        console.log(`model.run() took ${eT} ms`);
+        const executionTime = endTime - startTime;
+        setExecutionTime(executionTime);
+        console.log(`model.run() took ${executionTime} ms`);
         const output = results[model.outputNames[0]];
         // The predicted mask returned from the ONNX model is an array which is 
         // rendered as an HTML image using onnxMaskToImage() from maskUtils.tsx.

--- a/demo/src/components/Stage.tsx
+++ b/demo/src/components/Stage.tsx
@@ -44,7 +44,7 @@ const Stage = () => {
         <Tool handleMouseMove={handleMouseMove} />
       </div>
       <div className="mt-2">
-        Segment Anything Asynchronous Execution Time (ms): {executionTime}
+        { executionTime ? `Segment Anything Asynchronous Execution Time: ${executionTime?.toFixed(2)}ms` : `` }
       </div>
     </div>
   );


### PR DESCRIPTION
1. Show execution time with fixed-point notation format (2 digits to appear after the decimal point) in web page (keep raw data in `console.log()`)
2. Only show the execution time result when `execututionTime` resturns `true`

@fdwr PTAL if you need this change or not.

We also added url search params to make the comparison easier for the demo as follows, not sure if you need this on your side.

```
backend: wasm env.wasm.numThreads: 1

https://10.239.115.77:8081/
https://10.239.115.77:8081/?backend=wasm
https://10.239.115.77:8081/?backend=wasm&threads=1
```

```
backend: wasm
env.wasm.numThreads: 4
https://10.239.115.77:8081/?backend=wasm&threads=4
```

```
backend: webnn
deviceType: "gpu"
https://10.239.115.77:8081/?backend=webnn
```

![sa](https://github.com/fdwr/segment-anything/assets/5017359/2a2e91d4-f70d-402a-9be9-16272ec58590)
